### PR TITLE
Passing the source path to the riot compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ var riot = require('riot');
 
 module.exports = function(source) {
   var query = loaderUtils.parseQuery(this.query);
-  return 'var riot = require("riot");\n\n' + riot.compile(source, query);
+  return 'var riot = require("riot");\n\n' + riot.compile(source, query, source);
 };


### PR DESCRIPTION
We have updated our compiler and the source path to the file is needed as third parameter to the `compile` method. Please update your webpack plugin 
